### PR TITLE
Compress the final CSS files + remove CSS comments

### DIFF
--- a/assets/scss/_bootstrap-custom.scss
+++ b/assets/scss/_bootstrap-custom.scss
@@ -1,8 +1,8 @@
-/*!
- * Bootstrap v3.3.6 (http://getbootstrap.com)
- * Copyright 2011-2015 Twitter, Inc.
- * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
- */
+////////////////////////////////////////////////////////////////////////////////
+// Bootstrap v3.3.6 (http://getbootstrap.com)
+// Copyright 2011-2015 Twitter, Inc.
+// Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+////////////////////////////////////////////////////////////////////////////////
 
 // Core variables and mixins
 @import "bootstrap-variables";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,11 @@ var jsFileListFED = [
 gulp.task( 'sass', function() {
     gulp.src('./assets/scss/wp-stripe-styles.scss')
         .pipe(sourcemaps.init())
-        .pipe(sass().on('error', sass.logError))
+        .pipe(sass({
+            outputStyle: 'compressed'
+          })
+          .on('error', sass.logError)
+        )
         .pipe(sourcemaps.write())
         .pipe(gulp.dest('./build/css'));
 });
@@ -37,7 +41,11 @@ gulp.task( 'sass', function() {
 gulp.task( 'sassFED', function() {
     gulp.src('./assets/scss/wp-stripe-fed-styles.scss')
         .pipe(sourcemaps.init())
-        .pipe(sass().on('error', sass.logError))
+        .pipe(sass({
+            outputStyle: 'compressed'
+          })
+          .on('error', sass.logError)
+        )
         .pipe(sourcemaps.write())
         .pipe(gulp.dest('./build/front-end/css'));
 });


### PR DESCRIPTION
The final CSS files are compiled in their full version. To trim down the final files and optimize resources, the native node-sass outputStyle option is added with a 'compressed' value, which removes all spaces and comments.

The savings is about ~5% over the non-compressed CSS files. :smile: :art: 

Also, in the `assets/scss/_bootstrap.scss` file, removed native CSS commenting syntax in favor of Sass commenting syntax so that it doesn't get compiled in our final CSS file. :art: 
